### PR TITLE
Configure Hugo build settings in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,8 @@
 [build]
-  environment = { RUBY_VERSION = "2.7.2" }
+  command = "hugo -D"
+  publish = "public"
+
+  [build.environment]
+    HUGO_VERSION = "0.120.4"
+    NODE_VERSION = "18"
+    RUBY_VERSION = "2.7.2"


### PR DESCRIPTION
## Summary
Updated the Netlify configuration to properly set up Hugo as the static site generator with the necessary build command and environment variables.

## Key Changes
- Added `command = "hugo -D"` to build the site using Hugo with draft posts enabled
- Set `publish = "public"` to specify the output directory for built assets
- Restructured environment variables under `[build.environment]` section
- Added `HUGO_VERSION = "0.120.4"` to pin a specific Hugo version
- Added `NODE_VERSION = "18"` for Node.js support
- Retained `RUBY_VERSION = "2.7.2"` for any Ruby dependencies

## Implementation Details
The configuration now explicitly declares the build process and output directory, ensuring consistent builds on Netlify. The environment variables are properly scoped under the build configuration section, and specific versions are pinned for reproducibility.

https://claude.ai/code/session_01CuAbxw2gchTTLVhPRqX2Q1