### PR TITLE
Fix deprecated .Hugo.Generator template call

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,7 +3,7 @@
 <base href="{{ .Site.BaseURL }}">
 {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
 {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 <title>{{ .Title }}</title>
 <link rel="shortcut icon" href="{{ "/images/favicon.ico" | absURL }}" type="">
 <link href="https://fonts.googleapis.com/css?family=Merriweather|Playfair+Display|EB+Garamond|Roboto+Slab" rel="stylesheet">


### PR DESCRIPTION
Replace .Hugo.Generator with hugo.Generator — the page-scoped .Hugo variable was removed in Hugo v0.120+, causing render failures.

https://claude.ai/code/session_01CuAbxw2gchTTLVhPRqX2Q1